### PR TITLE
Use Mac & Linux compatible docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       - deps:/opt/app/deps
       # NOTE Issue Gleam shouldn't delete gen directory.
       # - gen:/opt/app/gen
-    network_mode: host
+    ports:
+      - "9000:9000"
     environment:
       PORT: 9000


### PR DESCRIPTION
`network_mode: host` is not supported with Docker for Mac https://docs.docker.com/compose/compose-file/#ports